### PR TITLE
Adapt transformers to the channel-based contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,16 +308,15 @@ feed a queue of tags worth searching. The store side is the
 One wrinkle worth knowing up front: both `mysql-table` and `mysql-filter`
 operate on **one scalar field per record** (`fields = ["tag"]` → a record
 shaped `{"tag": "cats"}`). `ifunny-tags` emits the whole list as one record
-(`{"tags": [...]}`), because a psyduck transformer is strictly one-in-one-out
-and can't fan a post's N tags into N records. So between `ifunny-tags` and the
-per-tag mysql stages you need an **explode** step — one record per tag — which
-psyduck has no primitive for yet. Options, cheapest first:
+(`{"tags": [...]}`) and doesn't fan a post's N tags into N records. So between
+`ifunny-tags` and the per-tag mysql stages you need an **explode** step — one
+record per tag — which psyduck has no primitive for yet. Options, cheapest
+first:
 
 1. Store the array whole (`mysql-table` with a JSON/text column) and aggregate
    counts in SQL (`GROUP BY` over an unnested tags column).
-2. Add a fan-out capability to the psyduck core (a transformer that may emit
-   many records, or a dedicated explode block) — this is the general fix and
-   would live in `gastrodon/psyduck`.
+2. An explode transformer (the channel-based Transformer contract supports
+   1-to-many, so this is now just a stdlib/plugin feature, not a core change).
 
 Instance **counts** ("how many times a tag has been seen") likewise aren't what
 `mysql-table` records today — `INSERT IGNORE` tracks distinct existence, not a

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/open-ifunny/ifunny-go v0.1.3
-	github.com/psyduck-etl/sdk v0.5.3-0.20260714042419-ef56644f8e74
+	github.com/psyduck-etl/sdk v0.5.3-0.20260714064906-ad34ade18836
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/open-ifunny/ifunny-go v0.1.3 h1:SQsLh0BwJ83nyfUI2NebWWlhUrxGKBB3wuuKS
 github.com/open-ifunny/ifunny-go v0.1.3/go.mod h1:yq3qwrY4DSHkQolejEapLKEHHgIg+rJoE4U1iYjB4fw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/psyduck-etl/sdk v0.5.3-0.20260714042419-ef56644f8e74 h1:8De/Xby+HSj4CdB9ZVS8hLztIqjX/jpg6o/lZcpEhZ8=
-github.com/psyduck-etl/sdk v0.5.3-0.20260714042419-ef56644f8e74/go.mod h1:NdqD30whD731zzGD4CK9beh63nFC63VKsAfkQ9ERZjw=
+github.com/psyduck-etl/sdk v0.5.3-0.20260714064906-ad34ade18836 h1:EpPV62WPNBPHSFyTu409nL9dtDlTYP/p+K4l8CKLvBY=
+github.com/psyduck-etl/sdk v0.5.3-0.20260714064906-ad34ade18836/go.mod h1:NdqD30whD731zzGD4CK9beh63nFC63VKsAfkQ9ERZjw=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartystreets/assertions v0.0.0-20160707190355-2063fd1cc7c9 h1:Kg4w5zDU3jgGRghptweqKKNAADO4nqR0Grd9WomB8H4=

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/psyduck-etl/sdk"
@@ -264,13 +265,48 @@ func mustBind(t *testing.T, accept, emit string, plan enrichPlan) sdk.Transforme
 	return tr
 }
 
+// runOne feeds a single record through tr under the channel-based
+// Transformer contract, mirroring the old 1→1 call shape for tests: the
+// emitted record (nil = dropped) and the first reported error.
+func runOne(t *testing.T, tr sdk.Transformer, data []byte) ([]byte, error) {
+	t.Helper()
+	in := make(chan []byte, 1)
+	out := make(chan []byte, 1)
+	errs := make(chan error, 1)
+	in <- data
+	close(in)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		tr(t.Context(), in, out, errs)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("transformer hung on a single record")
+	}
+
+	var b []byte
+	select {
+	case b = <-out:
+	default:
+	}
+	var err error
+	select {
+	case err = <-errs:
+	default:
+	}
+	return b, err
+}
+
 // sparse in + sparse out: resolve echoes the ref through; no extract,
 // no fetch.
 func TestBindEnrichSparseIn_SparseOut(t *testing.T) {
 	c := &enrichCounters{}
 	tr := mustBind(t, "string", "string", fakePlan("test", c, nil, false))
 
-	b, err := tr([]byte("xyz"))
+	b, err := runOne(t, tr, []byte("xyz"))
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -287,7 +323,7 @@ func TestBindEnrichSparseIn_RichOut(t *testing.T) {
 	c := &enrichCounters{}
 	tr := mustBind(t, "string", "json", fakePlan("test", c, &testEntity{Name: "resolved"}, false))
 
-	b, err := tr([]byte("xyz"))
+	b, err := runOne(t, tr, []byte("xyz"))
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -309,7 +345,7 @@ func TestBindEnrichRichIn_SparseOut(t *testing.T) {
 	c := &enrichCounters{}
 	tr := mustBind(t, "json", "string", fakePlan("test", c, nil, false))
 
-	b, err := tr([]byte(`{"target-ref":"abc","other":"ignored"}`))
+	b, err := runOne(t, tr, []byte(`{"target-ref":"abc","other":"ignored"}`))
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -327,7 +363,7 @@ func TestBindEnrichRichIn_RichOut(t *testing.T) {
 	c := &enrichCounters{}
 	tr := mustBind(t, "json", "json", fakePlan("test", c, &testEntity{Name: "fresh"}, false))
 
-	b, err := tr([]byte(`{"target-ref":"abc","name":"stale-cache"}`))
+	b, err := runOne(t, tr, []byte(`{"target-ref":"abc","name":"stale-cache"}`))
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -349,7 +385,7 @@ func TestBindEnrichRichIn_RichOut_ShortCircuit(t *testing.T) {
 	c := &enrichCounters{}
 	tr := mustBind(t, "json", "json", fakePlan("test", c, &testEntity{Name: "recovered"}, true))
 
-	b, err := tr([]byte(`{"target-ref":"abc"}`))
+	b, err := runOne(t, tr, []byte(`{"target-ref":"abc"}`))
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -371,7 +407,7 @@ func TestBindEnrichRichIn_EmptyRefDrops(t *testing.T) {
 	c := &enrichCounters{}
 	tr := mustBind(t, "json", "json", fakePlan("test", c, &testEntity{Name: "fresh"}, false))
 
-	b, err := tr([]byte(`{"other":"foo"}`))
+	b, err := runOne(t, tr, []byte(`{"other":"foo"}`))
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -390,7 +426,7 @@ func TestBindEnrichNotFoundDrops(t *testing.T) {
 	// resolved == nil → fetch returns (nil, nil).
 	tr := mustBind(t, "string", "json", fakePlan("test", c, nil, false))
 
-	b, err := tr([]byte("missing"))
+	b, err := runOne(t, tr, []byte("missing"))
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -432,7 +468,7 @@ func TestBindEnrichUnfetchableRichOK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bindEnrich: %v", err)
 	}
-	b, err := tr([]byte(`{"target-ref":"abc"}`))
+	b, err := runOne(t, tr, []byte(`{"target-ref":"abc"}`))
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -441,8 +477,8 @@ func TestBindEnrichUnfetchableRichOK(t *testing.T) {
 	}
 }
 
-// An extract that returns an error surfaces per-record (SDK v0.5.2
-// per-record transformer contract).
+// An extract that returns an error surfaces per-record on errs, and the
+// record drops without halting the stage.
 func TestBindEnrichExtractErrorPropagates(t *testing.T) {
 	sentinel := errors.New("shadow decode failed")
 	plan := enrichPlan{
@@ -454,7 +490,7 @@ func TestBindEnrichExtractErrorPropagates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bindEnrich: %v", err)
 	}
-	if _, err := tr([]byte(`{}`)); !errors.Is(err, sentinel) {
+	if _, err := runOne(t, tr, []byte(`{}`)); !errors.Is(err, sentinel) {
 		t.Errorf("err = %v, want sentinel", err)
 	}
 }
@@ -556,7 +592,7 @@ func TestTagsTransformer(t *testing.T) {
 		if err != nil {
 			t.Fatalf("bind: %v", err)
 		}
-		out, err := tr([]byte(`{"tags":["cats","memes"]}`))
+		out, err := runOne(t, tr, []byte(`{"tags":["cats","memes"]}`))
 		if err != nil {
 			t.Fatalf("tr: %v", err)
 		}
@@ -574,7 +610,7 @@ func TestTagsTransformer(t *testing.T) {
 		if err != nil {
 			t.Fatalf("bind: %v", err)
 		}
-		out, err := tr([]byte(`{"tags":["a", 1, "b", null, "c"]}`))
+		out, err := runOne(t, tr, []byte(`{"tags":["a", 1, "b", null, "c"]}`))
 		if err != nil {
 			t.Fatalf("tr: %v", err)
 		}
@@ -592,7 +628,7 @@ func TestTagsTransformer(t *testing.T) {
 		if err != nil {
 			t.Fatalf("bind: %v", err)
 		}
-		out, err := tr([]byte(`{"tags":[]}`))
+		out, err := runOne(t, tr, []byte(`{"tags":[]}`))
 		if err != nil {
 			t.Fatalf("tr: %v", err)
 		}
@@ -606,7 +642,7 @@ func TestTagsTransformer(t *testing.T) {
 		if err != nil {
 			t.Fatalf("bind: %v", err)
 		}
-		_, err = tr([]byte(`{"other":"value"}`))
+		_, err = runOne(t, tr, []byte(`{"other":"value"}`))
 		if err == nil || !strings.Contains(err.Error(), "no id field") {
 			t.Errorf("err = %v, want no-id fallback error", err)
 		}

--- a/transform.go
+++ b/transform.go
@@ -153,16 +153,16 @@ func bindEnrich(accept *acceptConfig, emit *emitConfig, plan enrichPlan) (sdk.Tr
 	}
 
 	if emit.sparse() {
-		return func(data []byte) ([]byte, error) {
+		return sdk.Map(func(data []byte) ([]byte, error) {
 			ref, _, err := frontHalf(data)
 			if err != nil || ref == "" {
 				return nil, err
 			}
 			return emit.Encode(ref)
-		}, nil
+		}), nil
 	}
 
-	return func(data []byte) ([]byte, error) {
+	return sdk.Map(func(data []byte) ([]byte, error) {
 		ref, target, err := frontHalf(data)
 		if err != nil {
 			return nil, err
@@ -177,7 +177,7 @@ func bindEnrich(accept *acceptConfig, emit *emitConfig, plan enrichPlan) (sdk.Tr
 			}
 		}
 		return emit.Encode(target)
-	}, nil
+	}), nil
 }
 
 // authorTransformer builds the ifunny-author transformer. It maps a
@@ -371,9 +371,9 @@ func authorTransformer(parse sdk.Parser) (sdk.Transformer, error) {
 // A post with no tags is dropped (an empty tag set contributes nothing
 // to a census). Requires auth (fetches are possible on either accept).
 //
-// Note the shape: this emits the whole list as one record, because a
-// psyduck transformer is strictly one-in-one-out. Per-tag consumers
-// therefore need an explode step upstream of them — see the README.
+// Note the shape: this emits the whole list as one record. Per-tag
+// consumers therefore need an explode step upstream of them — see the
+// README.
 //
 // Example:
 //
@@ -426,7 +426,7 @@ func tagsTransformer(parse sdk.Parser) (sdk.Transformer, error) {
 		return content.Tags, nil
 	}
 
-	return func(data []byte) ([]byte, error) {
+	return sdk.Map(func(data []byte) ([]byte, error) {
 		decoded, err := config.acceptConfig.Decode(data)
 		if err != nil {
 			return nil, err
@@ -468,7 +468,7 @@ func tagsTransformer(parse sdk.Parser) (sdk.Transformer, error) {
 			return nil, nil // drop
 		}
 		return config.emitConfig.Encode(tagsEnvelope{Tags: tags})
-	}, nil
+	}), nil
 }
 
 // contentTransformer builds the ifunny-content transformer. It hydrates


### PR DESCRIPTION
Stacked on #10; pairs with psyduck-etl/sdk#10. All five transformers (four enrichers + tags) wrap their per-record closures in `sdk.Map`; behavior unchanged. Bumps sdk to the streaming-transform head.

Note: explode-style 1→N emission is now expressible in the contract but not adopted here — the enrichers stay 1→1.