### PR TITLE
Add indefinite 429 backoff via retrying HTTP transport

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"io"
+	"math/rand"
+	"net/http"
+	"time"
+)
+
+const (
+	// backoffBase is the first backoff interval after a 429; each
+	// subsequent consecutive 429 doubles it.
+	backoffBase = 2 * time.Second
+
+	// backoffMaxShift caps the doubling. The ceiling is
+	// backoffBase << backoffMaxShift = 2s << 12 = 8192s (~2.3h); past
+	// that the interval holds at the ceiling and we keep retrying there
+	// forever. 12 is the shift that lifts a 2s base into the "few hours"
+	// order of magnitude without overshooting into days.
+	backoffMaxShift = 12
+
+	// backoffJitter scales each sleep by a uniform random factor in
+	// [1-backoffJitter, 1+backoffJitter] — i.e. ±10%. Independent jobs
+	// that hit a 429 in lockstep drift apart instead of re-colliding on
+	// every retry, so their load staggers rather than pulsing together.
+	backoffJitter = 0.10
+)
+
+// retryTransport wraps an http.RoundTripper, retrying HTTP 429 (Too Many
+// Requests) responses indefinitely with jittered exponential backoff. The
+// interval doubles from backoffBase up to the backoffMaxShift ceiling, then
+// holds there forever. Everything else — success, other status codes, and
+// the transport's own errors — passes straight through untouched; this only
+// addresses upstream rate limiting.
+//
+// RoundTrip holds no mutable state, so a single retryTransport is safe to
+// share across the concurrent goroutines the iterator/fan-out transformers
+// spin up.
+type retryTransport struct {
+	base http.RoundTripper
+}
+
+// backoffSleep is the sleep the retry loop uses between attempts. It is a
+// package var (like clientFor) so tests can swap in a no-op that records the
+// requested intervals instead of blocking on real, hours-long backoffs.
+var backoffSleep = sleepCtx
+
+func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	for attempt := 0; ; attempt++ {
+		// Rewind the body on every retry. http.NewRequestWithContext
+		// populates GetBody for the in-memory bodies iFunny's login/prime
+		// POSTs use, so a consumed body can be replayed; GET requests
+		// carry no body and skip this.
+		if attempt > 0 && req.GetBody != nil {
+			body, err := req.GetBody()
+			if err != nil {
+				return nil, err
+			}
+			req.Body = body
+		}
+
+		resp, err := t.base.RoundTrip(req)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusTooManyRequests {
+			return resp, nil
+		}
+
+		// Drain and close so the connection returns to the pool before we
+		// sleep, then back off and retry the same request.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+
+		if err := backoffSleep(req.Context(), backoffFor(attempt)); err != nil {
+			return nil, err
+		}
+	}
+}
+
+// backoffFor returns the (jittered) sleep before the attempt-th retry.
+// attempt 0 yields backoffBase, doubling each step until the shift saturates
+// at backoffMaxShift, after which every attempt sits at the ceiling.
+func backoffFor(attempt int) time.Duration {
+	shift := min(attempt, backoffMaxShift)
+	d := backoffBase << shift
+	factor := 1 + (rand.Float64()*2-1)*backoffJitter
+	return time.Duration(float64(d) * factor)
+}
+
+// sleepCtx sleeps for d, returning early with ctx.Err() if ctx is cancelled
+// first so a cancelled stage aborts an in-flight backoff instead of waiting
+// out the full (potentially hours-long) interval.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// retryingHTTPClient clones http.DefaultClient and wraps its transport in a
+// retryTransport, preserving the standard connection pool and timeouts while
+// adding transparent 429 backoff. Passed to ifunny client constructors via
+// ifunny.WithHTTPClient.
+func retryingHTTPClient() *http.Client {
+	base := http.DefaultClient.Transport
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	c := *http.DefaultClient
+	c.Transport = &retryTransport{base: base}
+	return &c
+}

--- a/backoff.go
+++ b/backoff.go
@@ -34,11 +34,16 @@ const (
 // the transport's own errors — passes straight through untouched; this only
 // addresses upstream rate limiting.
 //
+// giveUpAfter bounds the retry: after that many consecutive 429 tries the
+// transport stops and returns the last 429 response so the caller sees the
+// rate-limit error. 0 keeps the retry unbounded.
+//
 // RoundTrip holds no mutable state, so a single retryTransport is safe to
 // share across the concurrent goroutines the iterator/fan-out transformers
 // spin up.
 type retryTransport struct {
-	base http.RoundTripper
+	base        http.RoundTripper
+	giveUpAfter uint
 }
 
 // backoffSleep is the sleep the retry loop uses between attempts. It is a
@@ -65,6 +70,13 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			return nil, err
 		}
 		if resp.StatusCode != http.StatusTooManyRequests {
+			return resp, nil
+		}
+
+		// attempt+1 tries have now returned 429. If a give-up bound is set
+		// and we've reached it, hand the 429 back to the caller (body
+		// intact) instead of retrying further.
+		if t.giveUpAfter != 0 && uint(attempt+1) >= t.giveUpAfter {
 			return resp, nil
 		}
 
@@ -105,14 +117,14 @@ func sleepCtx(ctx context.Context, d time.Duration) error {
 
 // retryingHTTPClient clones http.DefaultClient and wraps its transport in a
 // retryTransport, preserving the standard connection pool and timeouts while
-// adding transparent 429 backoff. Passed to ifunny client constructors via
-// ifunny.WithHTTPClient.
-func retryingHTTPClient() *http.Client {
+// adding transparent 429 backoff. giveUpAfter bounds the retry (0 =
+// unbounded). Passed to ifunny client constructors via ifunny.WithHTTPClient.
+func retryingHTTPClient(giveUpAfter uint) *http.Client {
 	base := http.DefaultClient.Transport
 	if base == nil {
 		base = http.DefaultTransport
 	}
 	c := *http.DefaultClient
-	c.Transport = &retryTransport{base: base}
+	c.Transport = &retryTransport{base: base, giveUpAfter: giveUpAfter}
 	return &c
 }

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// roundTripFunc adapts a function to http.RoundTripper so tests can script
+// per-attempt responses without a live server.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func resp(status int) *http.Response {
+	return &http.Response{StatusCode: status, Body: http.NoBody}
+}
+
+// TestBackoffFor pins the doubling schedule, the ceiling, and the jitter
+// envelope. Each interval must land within ±backoffJitter of 2s<<min(n,12).
+func TestBackoffFor(t *testing.T) {
+	for attempt := 0; attempt <= backoffMaxShift+3; attempt++ {
+		shift := min(attempt, backoffMaxShift)
+		want := backoffBase << shift
+		lo := time.Duration(float64(want) * (1 - backoffJitter))
+		hi := time.Duration(float64(want) * (1 + backoffJitter))
+		// Sample repeatedly since the jitter is random.
+		for range 100 {
+			got := backoffFor(attempt)
+			if got < lo || got > hi {
+				t.Fatalf("backoffFor(%d) = %s, want within [%s,%s] of %s", attempt, got, lo, hi, want)
+			}
+		}
+	}
+
+	// The ceiling: 2s << 12 = 8192s, in the "few hours" range as designed.
+	if ceiling := backoffBase << backoffMaxShift; ceiling != 8192*time.Second {
+		t.Fatalf("ceiling = %s, want 8192s", ceiling)
+	}
+}
+
+// TestRetryTransportPassthrough: a non-429 response returns immediately with
+// no backoff.
+func TestRetryTransportPassthrough(t *testing.T) {
+	defer restoreBackoffSleep()
+	slept := 0
+	backoffSleep = func(context.Context, time.Duration) error { slept++; return nil }
+
+	calls := 0
+	tr := &retryTransport{base: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return resp(http.StatusOK), nil
+	})}
+
+	r, err := tr.RoundTrip(newReq(t))
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if r.StatusCode != http.StatusOK || calls != 1 || slept != 0 {
+		t.Fatalf("status=%d calls=%d slept=%d, want 200/1/0", r.StatusCode, calls, slept)
+	}
+}
+
+// TestRetryTransportRetriesUntilSuccess: consecutive 429s are retried with a
+// growing backoff until a non-429 arrives.
+func TestRetryTransportRetriesUntilSuccess(t *testing.T) {
+	defer restoreBackoffSleep()
+	var intervals []time.Duration
+	backoffSleep = func(_ context.Context, d time.Duration) error {
+		intervals = append(intervals, d)
+		return nil
+	}
+
+	calls := 0
+	tr := &retryTransport{base: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		if calls <= 3 {
+			return resp(http.StatusTooManyRequests), nil
+		}
+		return resp(http.StatusOK), nil
+	})}
+
+	r, err := tr.RoundTrip(newReq(t))
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if r.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", r.StatusCode)
+	}
+	if calls != 4 {
+		t.Fatalf("calls = %d, want 4 (3 x 429 + 1 x 200)", calls)
+	}
+	if len(intervals) != 3 {
+		t.Fatalf("slept %d times, want 3", len(intervals))
+	}
+	// The intervals grow: attempt 0,1,2 map to 2s,4s,8s before jitter, so
+	// each must strictly exceed the last even accounting for ±10%.
+	if !(intervals[0] < intervals[1] && intervals[1] < intervals[2]) {
+		t.Errorf("intervals not increasing: %v", intervals)
+	}
+}
+
+// TestRetryTransportContextCancel: a cancelled context during backoff aborts
+// the retry loop and surfaces the ctx error rather than looping forever.
+func TestRetryTransportContextCancel(t *testing.T) {
+	defer restoreBackoffSleep()
+	backoffSleep = func(ctx context.Context, _ time.Duration) error {
+		return ctx.Err() // simulate ctx already done at sleep time
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tr := &retryTransport{base: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return resp(http.StatusTooManyRequests), nil
+	})}
+
+	_, err := tr.RoundTrip(newReq(t).WithContext(ctx))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}
+
+// TestSleepCtxCancels: sleepCtx returns promptly with the ctx error when the
+// context is cancelled before the (long) duration elapses.
+func TestSleepCtxCancels(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := sleepCtx(ctx, time.Hour); !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}
+
+func newReq(t *testing.T) *http.Request {
+	t.Helper()
+	r, err := http.NewRequest(http.MethodGet, "https://api.ifunny.test/v4/x", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	return r
+}
+
+func restoreBackoffSleep() { backoffSleep = sleepCtx }

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -41,6 +41,34 @@ func TestBackoffFor(t *testing.T) {
 	}
 }
 
+// TestBackoffForBounded guarantees the sleep is never unbounded: even with
+// jitter at its high extreme, and even for attempt counts far past the
+// ceiling, backoffFor stays at or below the jittered ceiling
+// (2s<<12 * 1.1 ~= 9011s) and never goes non-positive. Sampling attempts well
+// beyond backoffMaxShift guards the min() clamp — drop it and the raw
+// backoffBase<<attempt shift would grow until it overflows into a huge or
+// negative duration, which this test would catch.
+func TestBackoffForBounded(t *testing.T) {
+	ceiling := backoffBase << backoffMaxShift
+	maxJittered := time.Duration(float64(ceiling) * (1 + backoffJitter))
+	// The global floor: attempt 0 is the smallest interval, and jitter can
+	// only pull it down to backoffBase*(1-jitter) = 1.8s. That floor is low
+	// but strictly positive — a retry never fires back-to-back with no wait.
+	minFloor := time.Duration(float64(backoffBase) * (1 - backoffJitter))
+
+	for attempt := 0; attempt <= backoffMaxShift+64; attempt++ {
+		for range 100 {
+			got := backoffFor(attempt)
+			if got < minFloor {
+				t.Fatalf("backoffFor(%d) = %s below floor %s (want low but non-zero)", attempt, got, minFloor)
+			}
+			if got > maxJittered {
+				t.Fatalf("backoffFor(%d) = %s exceeds jittered ceiling %s", attempt, got, maxJittered)
+			}
+		}
+	}
+}
+
 // TestRetryTransportPassthrough: a non-429 response returns immediately with
 // no backoff.
 func TestRetryTransportPassthrough(t *testing.T) {

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -102,6 +102,64 @@ func TestRetryTransportRetriesUntilSuccess(t *testing.T) {
 	}
 }
 
+// TestRetryTransportGivesUp: with giveUpAfter set, the transport stops after
+// that many consecutive 429 tries and propagates the 429 response to the
+// caller instead of retrying forever.
+func TestRetryTransportGivesUp(t *testing.T) {
+	defer restoreBackoffSleep()
+	slept := 0
+	backoffSleep = func(context.Context, time.Duration) error { slept++; return nil }
+
+	calls := 0
+	tr := &retryTransport{
+		giveUpAfter: 3,
+		base: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			calls++
+			return resp(http.StatusTooManyRequests), nil
+		}),
+	}
+
+	r, err := tr.RoundTrip(newReq(t))
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if r.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429 propagated after give-up", r.StatusCode)
+	}
+	if calls != 3 {
+		t.Fatalf("calls = %d, want 3 (giveUpAfter)", calls)
+	}
+	// 3 tries → 2 sleeps between them; no sleep after the final give-up try.
+	if slept != 2 {
+		t.Fatalf("slept = %d, want 2", slept)
+	}
+}
+
+// TestRetryTransportGiveUpAfterOne: giveUpAfter=1 means a single try — a 429
+// propagates immediately with no backoff.
+func TestRetryTransportGiveUpAfterOne(t *testing.T) {
+	defer restoreBackoffSleep()
+	slept := 0
+	backoffSleep = func(context.Context, time.Duration) error { slept++; return nil }
+
+	calls := 0
+	tr := &retryTransport{
+		giveUpAfter: 1,
+		base: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			calls++
+			return resp(http.StatusTooManyRequests), nil
+		}),
+	}
+
+	r, err := tr.RoundTrip(newReq(t))
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if r.StatusCode != http.StatusTooManyRequests || calls != 1 || slept != 0 {
+		t.Fatalf("status=%d calls=%d slept=%d, want 429/1/0", r.StatusCode, calls, slept)
+	}
+}
+
 // TestRetryTransportContextCancel: a cancelled context during backoff aborts
 // the retry loop and surfaces the ctx error rather than looping forever.
 func TestRetryTransportContextCancel(t *testing.T) {

--- a/client.go
+++ b/client.go
@@ -16,10 +16,16 @@ import (
 // the string "generate" (mint and prime a fresh one at bind time), or
 // "generate-cache" (mint once and cache in $XDG_CACHE_HOME so subsequent
 // runs skip the ~15s priming handshake).
+//
+// GiveupRetryAfter caps the transparent 429 backoff (see backoff.go): after
+// that many consecutive rate-limited tries the transport gives up and
+// propagates the 429 to the caller. 0 (the default) keeps the retry
+// unbounded.
 type authConfig struct {
-	AuthBasic  string           `psy:"auth-basic"`
-	AuthBearer string           `psy:"auth-bearer"`
-	UserAgent  *userAgentConfig `psy:"user-agent"`
+	AuthBasic        string           `psy:"auth-basic"`
+	AuthBearer       string           `psy:"auth-bearer"`
+	UserAgent        *userAgentConfig `psy:"user-agent"`
+	GiveupRetryAfter uint             `psy:"giveup-retry-after"`
 }
 
 // userAgentConfig is the block that renders every request's user-agent.
@@ -91,8 +97,9 @@ func defaultClientFor(config *authConfig) (*ifunny.Client, error) {
 
 	// Every constructed client retries upstream 429s with backoff (see
 	// backoff.go). One retrying http.Client is shared across the mint +
-	// make calls the basic path may issue.
-	opts := []ifunny.Option{ifunny.WithHTTPClient(retryingHTTPClient())}
+	// make calls the basic path may issue. GiveupRetryAfter bounds the
+	// retry (0 = unbounded).
+	opts := []ifunny.Option{ifunny.WithHTTPClient(retryingHTTPClient(config.GiveupRetryAfter))}
 
 	if config.AuthBearer != "" {
 		return ifunny.MakeClient(context.Background(), config.AuthBearer, ua, opts...)

--- a/client.go
+++ b/client.go
@@ -89,10 +89,15 @@ func defaultClientFor(config *authConfig) (*ifunny.Client, error) {
 		return nil, err
 	}
 
+	// Every constructed client retries upstream 429s with backoff (see
+	// backoff.go). One retrying http.Client is shared across the mint +
+	// make calls the basic path may issue.
+	opts := []ifunny.Option{ifunny.WithHTTPClient(retryingHTTPClient())}
+
 	if config.AuthBearer != "" {
-		return ifunny.MakeClient(context.Background(), config.AuthBearer, ua)
+		return ifunny.MakeClient(context.Background(), config.AuthBearer, ua, opts...)
 	}
-	return basicClient(config.AuthBasic, ua)
+	return basicClient(config.AuthBasic, ua, opts...)
 }
 
 // basicClient resolves the auth-basic value into a client:
@@ -101,18 +106,18 @@ func defaultClientFor(config *authConfig) (*ifunny.Client, error) {
 //     then persist. A cached token is assumed still valid — invalidate by
 //     removing the cache file (see basicCachePath).
 //   - anything else:    treat the value as an already-primed literal token.
-func basicClient(auth string, ua ifunny.UserAgent) (*ifunny.Client, error) {
+func basicClient(auth string, ua ifunny.UserAgent, opts ...ifunny.Option) (*ifunny.Client, error) {
 	switch auth {
 	case "generate":
-		return mintPrimedClient(ua)
+		return mintPrimedClient(ua, opts...)
 	case "generate-cache":
 		if token, ok, err := loadCachedBasic(); err != nil {
 			return nil, fmt.Errorf("read basic-token cache: %w", err)
 		} else if ok {
-			return ifunny.MakeClientBasic(token, ua)
+			return ifunny.MakeClientBasic(token, ua, opts...)
 		}
 
-		client, token, err := mintPrimedClientWithToken(ua)
+		client, token, err := mintPrimedClientWithToken(ua, opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -121,24 +126,24 @@ func basicClient(auth string, ua ifunny.UserAgent) (*ifunny.Client, error) {
 		}
 		return client, nil
 	default:
-		return ifunny.MakeClientBasic(auth, ua)
+		return ifunny.MakeClientBasic(auth, ua, opts...)
 	}
 }
 
 // mintPrimedClient mints a fresh basic token, builds a client, and primes it.
-func mintPrimedClient(ua ifunny.UserAgent) (*ifunny.Client, error) {
-	client, _, err := mintPrimedClientWithToken(ua)
+func mintPrimedClient(ua ifunny.UserAgent, opts ...ifunny.Option) (*ifunny.Client, error) {
+	client, _, err := mintPrimedClientWithToken(ua, opts...)
 	return client, err
 }
 
 // mintPrimedClientWithToken is mintPrimedClient plus the raw token, so the
 // cache path can persist it after priming.
-func mintPrimedClientWithToken(ua ifunny.UserAgent) (*ifunny.Client, string, error) {
+func mintPrimedClientWithToken(ua ifunny.UserAgent, opts ...ifunny.Option) (*ifunny.Client, string, error) {
 	basic, err := ifunny.GenerateBasic()
 	if err != nil {
 		return nil, "", fmt.Errorf("generate basic token: %w", err)
 	}
-	client, err := ifunny.MakeClientBasic(basic, ua)
+	client, err := ifunny.MakeClientBasic(basic, ua, opts...)
 	if err != nil {
 		return nil, "", err
 	}

--- a/client.go
+++ b/client.go
@@ -17,7 +17,7 @@ import (
 // "generate-cache" (mint once and cache in $XDG_CACHE_HOME so subsequent
 // runs skip the ~15s priming handshake).
 //
-// GiveupRetryAfter caps the transparent 429 backoff (see backoff.go): after
+// RetryGiveupAfter caps the transparent 429 backoff (see backoff.go): after
 // that many consecutive rate-limited tries the transport gives up and
 // propagates the 429 to the caller. 0 (the default) keeps the retry
 // unbounded.
@@ -25,7 +25,7 @@ type authConfig struct {
 	AuthBasic        string           `psy:"auth-basic"`
 	AuthBearer       string           `psy:"auth-bearer"`
 	UserAgent        *userAgentConfig `psy:"user-agent"`
-	GiveupRetryAfter uint             `psy:"giveup-retry-after"`
+	RetryGiveupAfter uint             `psy:"retry-giveup-after"`
 }
 
 // userAgentConfig is the block that renders every request's user-agent.
@@ -97,9 +97,9 @@ func defaultClientFor(config *authConfig) (*ifunny.Client, error) {
 
 	// Every constructed client retries upstream 429s with backoff (see
 	// backoff.go). One retrying http.Client is shared across the mint +
-	// make calls the basic path may issue. GiveupRetryAfter bounds the
+	// make calls the basic path may issue. RetryGiveupAfter bounds the
 	// retry (0 = unbounded).
-	opts := []ifunny.Option{ifunny.WithHTTPClient(retryingHTTPClient(config.GiveupRetryAfter))}
+	opts := []ifunny.Option{ifunny.WithHTTPClient(retryingHTTPClient(config.RetryGiveupAfter))}
 
 	if config.AuthBearer != "" {
 		return ifunny.MakeClient(context.Background(), config.AuthBearer, ua, opts...)

--- a/spec.go
+++ b/spec.go
@@ -44,7 +44,7 @@ func clientSpecs() []*sdk.Spec {
 			Default:     "",
 		},
 		{
-			Name:        "giveup-retry-after",
+			Name:        "retry-giveup-after",
 			Description: "number of consecutive upstream-429 tries after which to give up and propagate the rate-limit error; 0 (default) retries with backoff indefinitely",
 			Type:        sdk.TypeInt,
 			Default:     0,

--- a/spec.go
+++ b/spec.go
@@ -44,6 +44,12 @@ func clientSpecs() []*sdk.Spec {
 			Default:     "",
 		},
 		{
+			Name:        "giveup-retry-after",
+			Description: "number of consecutive upstream-429 tries after which to give up and propagate the rate-limit error; 0 (default) retries with backoff indefinitely",
+			Type:        sdk.TypeInt,
+			Default:     0,
+		},
+		{
 			Name:        "user-agent",
 			Description: "device profile that renders the request user-agent",
 			Type:        sdk.TypeObject,


### PR DESCRIPTION
## Summary
- Adds a `retryTransport` (`http.RoundTripper`) that transparently retries upstream **429s indefinitely** with jittered exponential backoff.
- Interval starts at **2s**, doubles each consecutive 429, caps at `2s << 12` = **8192s (~2.3h)**, then holds at the ceiling forever.
- **±10% jitter** per sleep so independent jobs that hit the rate limit in lockstep drift apart instead of re-colliding on every retry.
- Wired at the single `defaultClientFor` chokepoint via `ifunny.WithHTTPClient`, so every call path — single fetches, all iterators, fan-out transformer goroutines, and the login/prime POSTs — gets backoff for free.

## Details
- Only 429s retry; other statuses and transport errors pass straight through.
- Respects `ctx`: a cancelled stage aborts an in-flight backoff rather than waiting out a multi-hour sleep.
- Drains + closes the 429 body before sleeping (connection reuse) and rewinds POST bodies via `GetBody`.
- `backoffSleep` is a package-var test seam (same idiom as `clientFor`).

## Test plan
- [x] `go test ./...` passes
- [x] Backoff schedule: doubling, `2s<<12` ceiling, ±10% jitter envelope
- [x] Non-429 passes through with no sleep
- [x] Consecutive 429s retried with growing intervals until a non-429 arrives
- [x] Cancelled context aborts the retry loop with the ctx error
- [x] No test hits the live iFunny API (fake `RoundTripper` + no real sleeps)